### PR TITLE
Allow undefined streaming status data

### DIFF
--- a/ui/src/stores/janus.ts
+++ b/ui/src/stores/janus.ts
@@ -15,8 +15,9 @@ const RTCPeerConnection = window.RTCPeerConnection.bind(window);
 
 function getJanusUri() {
   const hostname = window.location.hostname;
-  const uri = `ws://${hostname}:${import.meta.env.VITE_PRINTNANNY_EDGE_JANUS_WS_PORT
-    }`;
+  const uri = `ws://${hostname}:${
+    import.meta.env.VITE_PRINTNANNY_EDGE_JANUS_WS_PORT
+  }`;
   console.log(`Connecting to Janus signaling websocket: ${uri}`);
   return uri;
 }

--- a/ui/src/stores/janus.ts
+++ b/ui/src/stores/janus.ts
@@ -15,9 +15,8 @@ const RTCPeerConnection = window.RTCPeerConnection.bind(window);
 
 function getJanusUri() {
   const hostname = window.location.hostname;
-  const uri = `ws://${hostname}:${
-    import.meta.env.VITE_PRINTNANNY_EDGE_JANUS_WS_PORT
-  }`;
+  const uri = `ws://${hostname}:${import.meta.env.VITE_PRINTNANNY_EDGE_JANUS_WS_PORT
+    }`;
   console.log(`Connecting to Janus signaling websocket: ${uri}`);
   return uri;
 }
@@ -150,9 +149,8 @@ export const useJanusStore = defineStore({
         StreamingPlugin.EVENT.STREAMING_STATUS,
         (evtdata: any) => {
           console.log(
-            `${
-              janusStreamingPluginHandle.name
-            } streaming handle event status ${JSON.stringify(evtdata)}`
+            `${janusStreamingPluginHandle.name} streaming handle event status:`,
+            evtdata
           );
         }
       );


### PR DESCRIPTION
Janus STREAMING_STATUS can sometimes return `undefined` event data?

In that case, JSON.stringify will throw. Log the event object instead of attempting to serialize + log
```
index.f8c46f5c.js:35 SyntaxError: "undefined" is not valid JSON
    at JSON.parse (<anonymous>)
    at VideoView.a4a6b747.js:1:41497
    at async Promise.all (index 0)
    at async Proxy.connectJanus (VideoView.a4a6b747.js:1:41339)
    at async Proxy.startStream (VideoView.a4a6b747.js:1:48030)
    at async Proxy.toggleVideoPlayer (VideoView.a4a6b747.js:1:49296)
    at async X (VideoView.a4a6b747.js:1:51608)
P0 @ index.f8c46f5c.js:35
(anonymous) @ VideoView.a4a6b747.js:1
Promise.catch (async)
X @ VideoView.a4a6b747.js:1
tn @ index.f8c46f5c.js:1
gt @ index.f8c46f5c.js:1
n @ index.f8c46f5c.js:1
```