### PR TITLE
device info view on settings page

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if ! [ -d node ]; then
+  mkdir node
+  curl -L https://nodejs.org/dist/v18.12.0/node-v18.12.0-linux-x64.tar.xz \
+  | tar -xJ --strip-components=1 -C node
+fi
+
+export PATH="$PWD/node/bin:$PATH"

--- a/src/get_version_data.rs
+++ b/src/get_version_data.rs
@@ -1,0 +1,51 @@
+use actix_web::{get, web, Responder};
+use log::error;
+use serde::Serialize;
+use std::fs;
+use std::process::Command;
+
+#[derive(Serialize)]
+struct VersionData {
+    issue: String,
+    os_release: String,
+    printnanny_version: String,
+}
+
+#[get("/api/pi/version")]
+pub async fn get_version_data() -> impl Responder {
+    let issue_content = fs::read_to_string("/etc/issue")
+        .map(|data| data.trim().to_string())
+        .unwrap_or_else(|err| {
+            error!("could not open /etc/issue: {:?}", err);
+            return "could not load /etc/issue".to_string();
+        });
+
+    let os_release_content = fs::read_to_string("/etc/os-release")
+        .map(|data| data.trim().to_string())
+        .unwrap_or_else(|err| {
+            error!("could not open /etc/os-release: {:?}", err);
+            return "could not load /etc/os-release".to_string();
+        });
+
+    let printnanny_version_output = Command::new("printnanny")
+        .args(["--version"])
+        .output()
+        .map(|output| String::from_utf8(output.stdout))
+        .unwrap_or_else(|err| {
+            error!("could not invoke printnanny --version: {:?}", err);
+            return Ok("could not invoke printnanny --version".to_string());
+        })
+        .unwrap_or_else(|err| {
+            error!(
+                "bytes returned by printnanny --version were not UTF-8: {:?}",
+                err
+            );
+            return "could not decode printnanny version output as UTF-8".to_string();
+        });
+
+    web::Json(VersionData {
+        issue: issue_content,
+        os_release: os_release_content,
+        printnanny_version: printnanny_version_output,
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ use printnanny_dash::config;
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 const GIT_VERSION: &str = git_version!();
 
+mod get_version_data;
+
 #[actix_web::main]
 async fn main() -> Result<()> {
     env_logger::init();
@@ -18,7 +20,9 @@ async fn main() -> Result<()> {
     warn!("Version: {}", GIT_VERSION);
     HttpServer::new(move || {
         let generated = generate();
-        App::new().service(ResourceFiles::new("/*", generated).resolve_not_found_to_root())
+        App::new().
+            service(get_version_data::get_version_data).
+            service(ResourceFiles::new("/*", generated).resolve_not_found_to_root())
     })
     .workers(config.workers)
     .bind((config.host, config.port))?

--- a/ui/src/components/DeviceInfo.vue
+++ b/ui/src/components/DeviceInfo.vue
@@ -1,0 +1,33 @@
+<template>
+  <h3 class="text-lg font-bold text-gray-900 prose">PrintNanny Build Information (<span class="font-mono">/etc/issue</span>)</h3>
+  <pre class="mb-4 mx-4 bg-slate-200 p-2">{{ issue }}</pre>
+
+  <h3 class="text-lg font-bold text-gray-900 prose">PrintNanny OS Version (<span class="font-mono">/etc/os_release</span>)</h3>
+  <pre class="mb-4 mx-4 bg-slate-200 p-2">{{ os_release }}</pre>
+
+  <h3 class="text-lg font-bold text-gray-900 prose">PrintNanny CLI Version (<span class="font-mono">printnanny --version</span>)</h3>
+  <pre class="mb-4 mx-4 bg-slate-200 p-2">{{ printnanny_version }}</pre>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  data() {
+    return {
+      issue: "some issues",
+      os_release: "red hat linux 5.0 (hurricane)",
+      printnanny_version: "0.0 alpha",
+    }
+  },
+  created() {
+    window.fetch('/api/pi/version')
+    .then(response => response.json())
+    .then(data => {
+      this.issue = data.issue
+      this.os_release = data.os_release
+      this.printnanny_version = data.printnanny_version
+    })
+  }
+})
+</script>

--- a/ui/src/views/SettingsView.vue
+++ b/ui/src/views/SettingsView.vue
@@ -12,11 +12,18 @@
           <CloudAccountSettings />
         </div>
       </div>
+      <div class="mx-auto max-w-7xl sm:p-6 lg:p-8">
+        <h2 class="text-xl font-bold text-gray-900 prose">Device Information</h2>
+        <div class="rounded-lg border-4 border-dashed border-gray-200">
+          <DeviceInfo />
+        </div>
+      </div>
     </main>
   </div>
 </template>
 
 <script setup lang="ts">
 import CloudAccountSettings from "@/components/cloud/CloudAccountSettings.vue";
+import DeviceInfo from "@/components/DeviceInfo.vue";
 const pageTitle = "⚙️ Settings";
 </script>


### PR DESCRIPTION
Adds a section to the 'Settings' page of the edge dashboard to display various system information. It looks like this, if we squint and imagine my laptop is a printnanny device.

![image](https://user-images.githubusercontent.com/95389395/199656762-cbddaced-ec9b-407b-b4a4-0ee234c47b65.png)

closes https://github.com/bitsy-ai/printnanny-os/issues/126